### PR TITLE
Agrega modelo TasaResponse y deserialización con Gson

### DIFF
--- a/src/src/ConversorApp.java
+++ b/src/src/ConversorApp.java
@@ -1,7 +1,5 @@
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.Gson;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
@@ -36,12 +34,11 @@ public class ConversorApp {
 
         String body = respuesta.body();
 
-        //Conversión a JSON
-        JsonElement elemento = JsonParser.parseString(body);
-        JsonObject objectRoot = elemento.getAsJsonObject();
-
-        //Accediendo a JsonObject
-        double tasa = objectRoot.get("conversion_rate").getAsDouble();
-        return tasa;
+        TasaResponse tasa = new Gson().fromJson(body, TasaResponse.class);
+        if (tasa == null || !"success".equals(tasa.getResult())) {
+            System.out.println("Error en la respuesta: " + (tasa != null ? tasa.getResult() : "N/A"));
+            return 0.0;
+        }
+        return tasa.getConversion_rate();
     }
 }

--- a/src/src/TasaResponse.java
+++ b/src/src/TasaResponse.java
@@ -1,0 +1,22 @@
+public class TasaResponse {
+    private String result;
+    private double conversion_rate;
+    private String base_code;
+    private String target_code;
+
+    public String getResult() {
+        return result;
+    }
+
+    public double getConversion_rate() {
+        return conversion_rate;
+    }
+
+    public String getBase_code() {
+        return base_code;
+    }
+
+    public String getTarget_code() {
+        return target_code;
+    }
+}


### PR DESCRIPTION
## Summary
- Define clase `TasaResponse` para mapear respuestas JSON de tasa de conversión.
- Utiliza `Gson` en `obtenerTasa` y valida que el resultado sea `success` antes de usar `conversion_rate`.

## Testing
- `find src -name '*.java' > sources.txt` *(pass)*
- `javac @sources.txt` *(fails: package com.google.gson does not exist)*


------
https://chatgpt.com/codex/tasks/task_e_68a29a06e9c08330a0ef46ae8f39f99a